### PR TITLE
Fix install on RT5, add RT6 support, fix non-ASCII filenames causing a corrupt ZIP to be created...

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,5 @@
 html/Ticket/AttachmentZip/dhandler
-html/Callbacks/AttachmentZip/Ticket/Elements/ShowAttachments/AfterAttachmentTitleBox
+html/Callbacks/AttachmentZip/Ticket/Elements/ShowAttachments/BeforeList
 inc/Module/AutoInstall.pm
 inc/Module/Install.pm
 inc/Module/Install/AutoInstall.pm

--- a/MYMETA.json
+++ b/MYMETA.json
@@ -4,13 +4,13 @@
       "Richard G Harman Jr <rtx-attachmentszip+richard@richardharman.com>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Module::Install version 0.93, CPAN::Meta::Converter version 2.142690",
+   "generated_by" : "Module::Install version 0.93, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "unknown"
    ],
    "meta-spec" : {
       "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
-      "version" : "2"
+      "version" : 2
    },
    "name" : "RT-Extension-AttachmentZip",
    "no_index" : {
@@ -27,7 +27,7 @@
       },
       "configure" : {
          "requires" : {
-            "ExtUtils::MakeMaker" : "6.42"
+            "ExtUtils::MakeMaker" : "0"
          }
       },
       "runtime" : {
@@ -37,5 +37,6 @@
       }
    },
    "release_status" : "stable",
-   "version" : "1.0"
+   "version" : "1.0",
+   "x_serialization_backend" : "JSON::PP version 4.06"
 }

--- a/MYMETA.yml
+++ b/MYMETA.yml
@@ -5,9 +5,9 @@ author:
 build_requires:
   ExtUtils::MakeMaker: '6.36'
 configure_requires:
-  ExtUtils::MakeMaker: '6.42'
+  ExtUtils::MakeMaker: '0'
 dynamic_config: 0
-generated_by: 'Module::Install version 0.93, CPAN::Meta::Converter version 2.142690'
+generated_by: 'Module::Install version 0.93, CPAN::Meta::Converter version 2.150010'
 license: unknown
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
@@ -20,3 +20,4 @@ no_index:
 requires:
   Archive::Zip: '0'
 version: '1.0'
+x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,4 @@
+use lib '.';
 use inc::Module::Install;
 
 license('GPL Version 2');
@@ -9,6 +10,11 @@ requires_rt '4.0.0';
 rt_too_new '4.6.0';
 
 version_from('lib/RT/Extension/AttachmentZip.pm');
+
+my ($lib_path) = $INC{'RT.pm'} =~ /^(.*)[\\\/]/;
+my $local_lib_path = "$RT::LocalPath/lib";
+unshift @INC, $local_lib_path, $lib_path;
+
 
 substitute(
     { RT_LIB_PATH => "$RT::LocalPath/lib " . File::Basename::dirname( $INC{'RT.pm'} ) },

--- a/html/Callbacks/AttachmentZip/Ticket/Elements/ShowAttachments/BeforeList
+++ b/html/Callbacks/AttachmentZip/Ticket/Elements/ShowAttachments/BeforeList
@@ -1,7 +1,7 @@
 <table width="100%"><tr><td align="right"><font size="-1">
 Download attachments as zip |
 % foreach my $mode (("Latest Versions", "All")) {
-<a href="<%RT->Config->Get('WebPath')%>/Ticket/AttachmentZip/<%$mode%>/<%$Ticket->Id%>/Ticket_<%$Ticket->Id%>_attachments.zip"><%$mode%></a> |
+<a href="<%RT->Config->Get('WebPath')%>/Ticket/AttachmentZip/<%$mode%>/<%$Ticket->Id%>/Ticket_<%$Ticket->Id%>_attachments.zip" hx-boost="false"><%$mode%></a> |
 % }
 </font></td></tr></table>
 

--- a/html/Callbacks/AttachmentZip/Ticket/Elements/ShowAttachments/BeforeList
+++ b/html/Callbacks/AttachmentZip/Ticket/Elements/ShowAttachments/BeforeList
@@ -1,14 +1,17 @@
 <table width="100%"><tr><td align="right"><font size="-1">
 Download attachments as a zip archive |
-% foreach my $mode (qw(Current All)) {
+% foreach my $mode (("Latest Versions", "All")) {
 <a href="<%RT->Config->Get('WebPath')%>/Ticket/AttachmentZip/<%$mode%>/<%$Ticket->Id%>/Ticket_<%$Ticket->Id%>_attachments.zip"><%$mode%></a> |
 % }
 </font></td></tr></table>
 
 <%init>
+return if $$ShowMore == 0 && not defined $Count;
 </%init>
 
 <%ARGS>
 $Ticket => undef
+$Count => undef
+$ShowMore => \0
 </%ARGS>
 

--- a/html/Callbacks/AttachmentZip/Ticket/Elements/ShowAttachments/BeforeList
+++ b/html/Callbacks/AttachmentZip/Ticket/Elements/ShowAttachments/BeforeList
@@ -1,5 +1,5 @@
 <table width="100%"><tr><td align="right"><font size="-1">
-Download attachments as a zip archive |
+Download attachments as zip |
 % foreach my $mode (("Latest Versions", "All")) {
 <a href="<%RT->Config->Get('WebPath')%>/Ticket/AttachmentZip/<%$mode%>/<%$Ticket->Id%>/Ticket_<%$Ticket->Id%>_attachments.zip"><%$mode%></a> |
 % }

--- a/html/Callbacks/AttachmentZip/Ticket/Elements/ShowAttachments/BeforeList
+++ b/html/Callbacks/AttachmentZip/Ticket/Elements/ShowAttachments/BeforeList
@@ -6,12 +6,16 @@ Download attachments as zip |
 </font></td></tr></table>
 
 <%init>
-return if $$ShowMore == 0 && not defined $Count;
+return if (
+  ($$ShowMore == 0 && not defined $Count)
+  or $HideTitleBox == 1
+);
 </%init>
 
 <%ARGS>
 $Ticket => undef
 $Count => undef
 $ShowMore => \0
+$HideTitleBox => 0
 </%ARGS>
 

--- a/html/Ticket/AttachmentZip/dhandler
+++ b/html/Ticket/AttachmentZip/dhandler
@@ -113,4 +113,9 @@ AutoFlush => 0
 <%once>
 use Archive::Zip qw( :ERROR_CODES :CONSTANTS);
 use File::Temp qw( tempfile tempdir);
+
+# This seems to be necessary within RT for reasons unknown - if we wind up
+# dealing with a filename with anything but ASCII chars, we stand a good chance
+# of winding up with a corrupt zip.
+$Archive::Zip::UNICODE = 1;
 </%once>

--- a/html/Ticket/AttachmentZip/dhandler
+++ b/html/Ticket/AttachmentZip/dhandler
@@ -1,6 +1,6 @@
 <%init>
 # grab ticket number from URL
-my ($mode,$ticket_no) = ($m->dhandler_arg =~ m/^((?:all|current))\/(\d+)\//i );
+my ($mode,$ticket_no) = ($m->dhandler_arg =~ m/^((?:all|latest versions))\/(\d+)\//i );
 
 # create ticket object
 my $Ticket = LoadTicket($ticket_no);

--- a/inc/Module/Install.pm
+++ b/inc/Module/Install.pm
@@ -31,7 +31,7 @@ BEGIN {
 	# This is not enforced yet, but will be some time in the next few
 	# releases once we can make sure it won't clash with custom
 	# Module::Install extensions.
-	$VERSION = '1.16';
+	$VERSION = '1.21';
 
 	# Storage for the pseudo-singleton
 	$MAIN    = undef;
@@ -244,6 +244,8 @@ sub new {
 	}
 	return $args{_self} if $args{_self};
 
+	$base_path = VMS::Filespec::unixify($base_path) if $^O eq 'VMS';
+
 	$args{dispatch} ||= 'Admin';
 	$args{prefix}   ||= 'inc';
 	$args{author}   ||= ($^O eq 'VMS' ? '_author' : '.author');
@@ -322,7 +324,7 @@ sub find_extensions {
 	my ($self, $path) = @_;
 
 	my @found;
-	File::Find::find( sub {
+	File::Find::find( {no_chdir => 1, wanted => sub {
 		my $file = $File::Find::name;
 		return unless $file =~ m!^\Q$path\E/(.+)\.pm\Z!is;
 		my $subpath = $1;
@@ -336,7 +338,7 @@ sub find_extensions {
 		# correctly.  Otherwise, root through the file to locate the case-preserved
 		# version of the package name.
 		if ( $subpath eq lc($subpath) || $subpath eq uc($subpath) ) {
-			my $content = Module::Install::_read($subpath . '.pm');
+			my $content = Module::Install::_read($File::Find::name);
 			my $in_pod  = 0;
 			foreach ( split /\n/, $content ) {
 				$in_pod = 1 if /^=\w/;
@@ -351,7 +353,7 @@ sub find_extensions {
 		}
 
 		push @found, [ $file, $pkg ];
-	}, $path ) if -d $path;
+	}}, $path ) if -d $path;
 
 	@found;
 }
@@ -373,8 +375,6 @@ sub _caller {
 	return $call;
 }
 
-# Done in evals to avoid confusing Perl::MinimumVersion
-eval( $] >= 5.006 ? <<'END_NEW' : <<'END_OLD' ); die $@ if $@;
 sub _read {
 	local *FH;
 	open( FH, '<', $_[0] ) or die "open($_[0]): $!";
@@ -383,16 +383,6 @@ sub _read {
 	close FH or die "close($_[0]): $!";
 	return $string;
 }
-END_NEW
-sub _read {
-	local *FH;
-	open( FH, "< $_[0]"  ) or die "open($_[0]): $!";
-	binmode FH;
-	my $string = do { local $/; <FH> };
-	close FH or die "close($_[0]): $!";
-	return $string;
-}
-END_OLD
 
 sub _readperl {
 	my $string = Module::Install::_read($_[0]);
@@ -413,8 +403,6 @@ sub _readpod {
 	return $string;
 }
 
-# Done in evals to avoid confusing Perl::MinimumVersion
-eval( $] >= 5.006 ? <<'END_NEW' : <<'END_OLD' ); die $@ if $@;
 sub _write {
 	local *FH;
 	open( FH, '>', $_[0] ) or die "open($_[0]): $!";
@@ -424,17 +412,6 @@ sub _write {
 	}
 	close FH or die "close($_[0]): $!";
 }
-END_NEW
-sub _write {
-	local *FH;
-	open( FH, "> $_[0]"  ) or die "open($_[0]): $!";
-	binmode FH;
-	foreach ( 1 .. $#_ ) {
-		print FH $_[$_] or die "print($_[0]): $!";
-	}
-	close FH or die "close($_[0]): $!";
-}
-END_OLD
 
 # _version is for processing module versions (eg, 1.03_05) not
 # Perl versions (eg, 5.8.1).

--- a/inc/Module/Install/Base.pm
+++ b/inc/Module/Install/Base.pm
@@ -4,7 +4,7 @@ package Module::Install::Base;
 use strict 'vars';
 use vars qw{$VERSION};
 BEGIN {
-	$VERSION = '1.16';
+	$VERSION = '1.21';
 }
 
 # Suspend handler for "redefined" warnings

--- a/inc/Module/Install/Can.pm
+++ b/inc/Module/Install/Can.pm
@@ -8,7 +8,7 @@ use Module::Install::Base ();
 
 use vars qw{$VERSION @ISA $ISCORE};
 BEGIN {
-	$VERSION = '1.16';
+	$VERSION = '1.21';
 	@ISA     = 'Module::Install::Base';
 	$ISCORE  = 1;
 }
@@ -121,6 +121,15 @@ END_C
 # Can we locate a (the) C compiler
 sub can_cc {
 	my $self   = shift;
+
+	if ($^O eq 'VMS') {
+		require ExtUtils::CBuilder;
+		my $builder = ExtUtils::CBuilder->new(
+		quiet => 1,
+		);
+		return $builder->have_compiler;
+	}
+
 	my @chunks = split(/ /, $Config::Config{cc}) or return;
 
 	# $Config{cc} may contain args; try to find out the program part
@@ -151,4 +160,4 @@ if ( $^O eq 'cygwin' ) {
 
 __END__
 
-#line 236
+#line 245

--- a/inc/Module/Install/Fetch.pm
+++ b/inc/Module/Install/Fetch.pm
@@ -6,7 +6,7 @@ use Module::Install::Base ();
 
 use vars qw{$VERSION @ISA $ISCORE};
 BEGIN {
-	$VERSION = '1.16';
+	$VERSION = '1.21';
 	@ISA     = 'Module::Install::Base';
 	$ISCORE  = 1;
 }

--- a/inc/Module/Install/Include.pm
+++ b/inc/Module/Install/Include.pm
@@ -6,7 +6,7 @@ use Module::Install::Base ();
 
 use vars qw{$VERSION @ISA $ISCORE};
 BEGIN {
-	$VERSION = '1.16';
+	$VERSION = '1.21';
 	@ISA     = 'Module::Install::Base';
 	$ISCORE  = 1;
 }

--- a/inc/Module/Install/Makefile.pm
+++ b/inc/Module/Install/Makefile.pm
@@ -8,7 +8,7 @@ use Fcntl qw/:flock :seek/;
 
 use vars qw{$VERSION @ISA $ISCORE};
 BEGIN {
-	$VERSION = '1.16';
+	$VERSION = '1.21';
 	@ISA     = 'Module::Install::Base';
 	$ISCORE  = 1;
 }

--- a/inc/Module/Install/Metadata.pm
+++ b/inc/Module/Install/Metadata.pm
@@ -6,7 +6,7 @@ use Module::Install::Base ();
 
 use vars qw{$VERSION @ISA $ISCORE};
 BEGIN {
-	$VERSION = '1.16';
+	$VERSION = '1.21';
 	@ISA     = 'Module::Install::Base';
 	$ISCORE  = 1;
 }
@@ -455,12 +455,8 @@ sub author_from {
 my %license_urls = (
     perl         => 'http://dev.perl.org/licenses/',
     apache       => 'http://apache.org/licenses/LICENSE-2.0',
-    apache_1_1   => 'http://apache.org/licenses/LICENSE-1.1',
     artistic     => 'http://opensource.org/licenses/artistic-license.php',
-    artistic_2   => 'http://opensource.org/licenses/artistic-license-2.0.php',
     lgpl         => 'http://opensource.org/licenses/lgpl-license.php',
-    lgpl2        => 'http://opensource.org/licenses/lgpl-2.1.php',
-    lgpl3        => 'http://opensource.org/licenses/lgpl-3.0.html',
     bsd          => 'http://opensource.org/licenses/bsd-license.php',
     gpl          => 'http://opensource.org/licenses/gpl-license.php',
     gpl2         => 'http://opensource.org/licenses/gpl-2.0.php',
@@ -471,6 +467,12 @@ my %license_urls = (
     unrestricted => undef,
     restrictive  => undef,
     unknown      => undef,
+
+    # these are not actually allowed in meta-spec v1.4 but are left here for compatibility:
+    apache_1_1   => 'http://apache.org/licenses/LICENSE-1.1',
+    artistic_2   => 'http://opensource.org/licenses/artistic-license-2.0.php',
+    lgpl2        => 'http://opensource.org/licenses/lgpl-2.1.php',
+    lgpl3        => 'http://opensource.org/licenses/lgpl-3.0.html',
 );
 
 sub license {

--- a/inc/Module/Install/RTx.pm
+++ b/inc/Module/Install/RTx.pm
@@ -6,9 +6,10 @@ use strict;
 use warnings;
 no warnings 'once';
 
+use Term::ANSIColor qw(:constants);
 use Module::Install::Base;
 use base 'Module::Install::Base';
-our $VERSION = '0.38';
+our $VERSION = '0.43';
 
 use FindBin;
 use File::Glob     ();
@@ -53,7 +54,7 @@ sub RTx {
         my @look = @INC;
         unshift @look, grep {defined and -d $_} @try;
         push @look, grep {defined and -d $_}
-            map { ( "$_/rt4/lib", "$_/lib/rt4", "$_/lib" ) } @prefixes;
+            map { ( "$_/rt5/lib", "$_/lib/rt5", "$_/rt4/lib", "$_/lib/rt4", "$_/lib" ) } @prefixes;
         last if eval {local @INC = @look; require RT; $RT::LocalLibPath};
 
         warn
@@ -74,6 +75,22 @@ sub RTx {
     # Set a baseline minimum version
     unless ( $extra_args->{deprecated_rt} ) {
         $self->requires_rt('4.0.0');
+    }
+
+    my $package = $name;
+    $package =~ s/-/::/g;
+    if ( $RT::CORED_PLUGINS{$package} ) {
+        my ($base_version) = $RT::VERSION =~ /(\d+\.\d+\.\d+)/;
+        die RED, <<"EOT";
+
+**** Error: Your installed version of RT ($RT::VERSION) already
+            contains this extension in core, so you don't need to
+            install it.
+
+            Check https://docs.bestpractical.com/rt/$base_version/RT_Config.html
+            to configure it.
+
+EOT
     }
 
     # Installation locations
@@ -113,11 +130,29 @@ lexicons ::
 .
     }
 
+    my $remove_files;
+    if( $extra_args->{'remove_files'} ){
+        $self->include('Module::Install::RTx::Remove');
+        our @remove_files;
+        eval { require "./etc/upgrade/remove_files" }
+          or print "No remove file located, no files to remove\n";
+        $remove_files = join ",", map {"q(\$(DESTDIR)$plugin_path/$name/$_)"} @remove_files;
+    }
+
     $self->include('Module::Install::RTx::Runtime') if $self->admin;
     $self->include_deps( 'YAML::Tiny', 0 ) if $self->admin;
     my $postamble = << ".";
 install ::
 \t\$(NOECHO) \$(PERL) -Ilib -I"$local_lib_path" -I"$lib_path" -Iinc -MModule::Install::RTx::Runtime -e"RTxPlugin()"
+.
+
+    if( $remove_files ){
+        $postamble .= << ".";
+\t\$(NOECHO) \$(PERL) -MModule::Install::RTx::Remove -e \"RTxRemove([$remove_files])\"
+.
+    }
+
+    $postamble .= << ".";
 \t\$(NOECHO) \$(PERL) -MExtUtils::Install -e \"install({$args})\"
 .
 
@@ -205,7 +240,7 @@ sub requires_rt {
     my @sorted = sort RT::Handle::cmp_version $version,$RT::VERSION;
 
     if ($sorted[-1] eq $version) {
-        die <<"EOT";
+        die RED, <<"EOT";
 
 **** Error: This extension requires RT $version. Your installed version
             of RT ($RT::VERSION) is too old.
@@ -231,12 +266,12 @@ sub requires_rt_plugin {
         unshift @INC, $path;
     } else {
         my $name = $self->name;
-        warn <<"EOT";
+        my $msg = <<"EOT";
 
 **** Warning: $name requires that the $plugin plugin be installed and
               enabled; it does not appear to be installed.
-
 EOT
+        warn RED, $msg, RESET, "\n";
     }
     $self->requires(@_);
 }
@@ -246,9 +281,8 @@ sub rt_too_new {
     my $name = $self->name;
     $msg ||= <<EOT;
 
-**** Error: Your installed version of RT (%s) is too new; this extension
-            only works with versions older than %s.
-
+**** Warning: Your installed version of RT (%s) is too new; this extension
+              has not been tested on your version of RT and may not work as expected.
 EOT
     $self->add_metadata("x_rt_too_new", $version) if $self->is_admin;
 
@@ -256,7 +290,7 @@ EOT
     my @sorted = sort RT::Handle::cmp_version $version,$RT::VERSION;
 
     if ($sorted[0] eq $version) {
-        die sprintf($msg,$RT::VERSION,$version);
+        warn RED, sprintf($msg,$RT::VERSION), RESET, "\n";
     }
 }
 
@@ -279,4 +313,4 @@ sub _load_rt_handle {
 
 __END__
 
-#line 428
+#line 484

--- a/inc/Module/Install/RTx/Runtime.pm
+++ b/inc/Module/Install/RTx/Runtime.pm
@@ -33,6 +33,7 @@ sub RTxDatabase {
 
     my $lib_path = File::Basename::dirname($INC{'RT.pm'});
     my @args = (
+        "-I.",
         "-Ilib",
         "-I$RT::LocalLibPath",
         "-I$lib_path",

--- a/inc/Module/Install/ReadmeFromPod.pm
+++ b/inc/Module/Install/ReadmeFromPod.pm
@@ -7,7 +7,7 @@ use warnings;
 use base qw(Module::Install::Base);
 use vars qw($VERSION);
 
-$VERSION = '0.26';
+$VERSION = '0.30';
 
 {
 

--- a/inc/Module/Install/Win32.pm
+++ b/inc/Module/Install/Win32.pm
@@ -6,7 +6,7 @@ use Module::Install::Base ();
 
 use vars qw{$VERSION @ISA $ISCORE};
 BEGIN {
-	$VERSION = '1.16';
+	$VERSION = '1.21';
 	@ISA     = 'Module::Install::Base';
 	$ISCORE  = 1;
 }

--- a/inc/Module/Install/WriteAll.pm
+++ b/inc/Module/Install/WriteAll.pm
@@ -6,7 +6,7 @@ use Module::Install::Base ();
 
 use vars qw{$VERSION @ISA $ISCORE};
 BEGIN {
-	$VERSION = '1.16';
+	$VERSION = '1.21';
 	@ISA     = qw{Module::Install::Base};
 	$ISCORE  = 1;
 }

--- a/lib/RT/Extension/AttachmentZip.pm
+++ b/lib/RT/Extension/AttachmentZip.pm
@@ -1,5 +1,5 @@
 package RT::Extension::AttachmentZip;
 
-our $VERSION = "2.0";
+our $VERSION = "2.1";
 
 1;

--- a/xt/lib/RT/Extension/AttachmentZip/Test.pm
+++ b/xt/lib/RT/Extension/AttachmentZip/Test.pm
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 
 ### after: use lib qw(@RT_LIB_PATH@);
-use lib qw(/opt/rt4/local/lib /opt/rt4/lib);
+use lib qw(/data1/opt/rt5/local/lib /opt/rt5/lib);
 
 package RT::Extension::AttachmentZip::Test;
 use base 'RT::Test';


### PR DESCRIPTION
It seems this repo is likely abandoned, but I'll try opening a PR with my changes anyway.

The only spurious change here is 762baa4, Change link names.  This was done as a matter of preference, and isn't required.  The rest of the changes fix functionality issues, from installing on RT5, to not working on the newly-released RT6, and even a corruption bug when non-ASCII filenames are used in attachments.